### PR TITLE
Only pass the last IP address from X-Forwarded-For

### DIFF
--- a/src/yaz-proxy.cpp
+++ b/src/yaz-proxy.cpp
@@ -2083,7 +2083,7 @@ void Yaz_Proxy::HTTP_Forwarded(Z_GDU *z_gdu)
         {
             if (!yaz_strcasecmp(header->name, "X-Forwarded-For"))
             {
-                auto pos = std::strrchr(header->value, 'n');
+                auto pos = std::strrchr(header->value, ',');
                 if (!pos)
                 {
                     // no comma found. this header line only has one ip

--- a/src/yaz-proxy.cpp
+++ b/src/yaz-proxy.cpp
@@ -2078,8 +2078,7 @@ void Yaz_Proxy::HTTP_Forwarded(Z_GDU *z_gdu)
         Z_HTTP_Request *hreq = z_gdu->u.HTTP_Request;
 
         const char *x_forwarded_for = nullptr;
-        auto header = hreq->headers;
-        while(header)
+        for (auto header = hreq->headers; header; header = header->next)
         {
             if (!yaz_strcasecmp(header->name, "X-Forwarded-For"))
             {
@@ -2096,7 +2095,6 @@ void Yaz_Proxy::HTTP_Forwarded(Z_GDU *z_gdu)
                     x_forwarded_for = pos;
                 }
             }
-            header = header->next;
         };
 
         if (x_forwarded_for)


### PR DESCRIPTION
This function used to stop at the first X-Forwarded-For header line and pass its value as-is along to authentication modules.  This way of parsing left out scenarios with multiple header lines with the same name, when it fact they should have been concatenated to a list and handled from left to right. Sometimes it also passed comma-separated IP address lists, which were still sometimes incomplete in situations like:

```
x-forwarded-for: 10.10.1.1,192.168.100.2
x-forwarded-for: 172.16.0.20
```

This patch changes the behavior so that the function now continues parsing header lines after the first match and discards all IP addresses apart from the last one. It also preferentially picks CF-Connecting-IP (Cloudflare's addition),
if found, because it will probably survive any further proxies after Cloudflare.

Motivation:
  https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#parsing
  https://developers.cloudflare.com/fundamentals/reference/http-headers/#x-forwarded-for